### PR TITLE
Allows `with_client` to use a pre-existing client.

### DIFF
--- a/lib/mysql_framework/connector.rb
+++ b/lib/mysql_framework/connector.rb
@@ -24,11 +24,11 @@ module MysqlFramework
     end
 
     # This method is called to use a client from the connection pool.
-    def with_client
-      client = check_out
+    def with_client(provided = nil)
+      client = provided || check_out
       yield client
     ensure
-      check_in(client) unless client.nil?
+      check_in(client) unless provided
     end
 
     # This method is called to execute a prepared statement

--- a/lib/mysql_framework/version.rb
+++ b/lib/mysql_framework/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module MysqlFramework
-  VERSION = '0.0.1'
+  VERSION = '0.0.2'
 end

--- a/spec/lib/mysql_framework/connector_spec.rb
+++ b/spec/lib/mysql_framework/connector_spec.rb
@@ -66,7 +66,12 @@ describe MysqlFramework::Connector do
   end
 
   describe '#with_client' do
-    it 'obtains a client from the pool to use' do
+    it 'uses the client that is provided, if passed one' do
+      expect(subject).not_to receive(:check_out)
+      expect { |b| subject.with_client(client, &b) }.to yield_with_args(client)
+    end
+
+    it 'obtains a client from the pool to use, if no client is provided' do
       allow(subject).to receive(:check_out).and_return(client)
       expect { |b| subject.with_client(&b) }.to yield_with_args(client)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,15 +1,18 @@
+# frozen_string_literal: true
+
 require 'simplecov'
+
 SimpleCov.start do
   add_filter 'spec/'
 end
 
-ENV['MYSQL_DATABASE']   ||= 'test_database'
-ENV['MYSQL_HOST']       ||= '127.0.0.1'
+ENV['MYSQL_DATABASE'] ||= 'test_database'
+ENV['MYSQL_HOST'] ||= '127.0.0.1'
 ENV['MYSQL_PARTITIONS'] ||= '5'
-ENV['MYSQL_PASSWORD']   ||= ''
-ENV['MYSQL_PORT']       ||= '3306'
-ENV['MYSQL_USERNAME']   ||= 'root'
-ENV['REDIS_URL']        ||= 'redis://127.0.0.1:6379'
+ENV['MYSQL_PASSWORD'] ||= ''
+ENV['MYSQL_PORT'] ||= '3306'
+ENV['MYSQL_USERNAME'] ||= 'root'
+ENV['REDIS_URL'] ||= 'redis://127.0.0.1:6379'
 
 require 'bundler'
 require 'mysql_framework'
@@ -22,6 +25,8 @@ require_relative 'support/tables/test'
 require_relative 'support/tables/demo'
 
 RSpec.configure do |config|
+  config.before(:each) { MysqlFramework.logger.level = Logger::ERROR }
+
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end
@@ -31,22 +36,24 @@ RSpec.configure do |config|
   end
 end
 
-client = Mysql2::Client.new({
-  host:      ENV.fetch('MYSQL_HOST'),
-  port:      ENV.fetch('MYSQL_PORT'),
-  username:  ENV.fetch('MYSQL_USERNAME'),
-  password:  ENV.fetch('MYSQL_PASSWORD'),
-})
+client = Mysql2::Client.new(
+  host: ENV.fetch('MYSQL_HOST'),
+  port: ENV.fetch('MYSQL_PORT'),
+  username: ENV.fetch('MYSQL_USERNAME'),
+  password: ENV.fetch('MYSQL_PASSWORD')
+)
 client.query("DROP DATABASE IF EXISTS `#{ENV.fetch('MYSQL_DATABASE')}`;")
 client.query("CREATE DATABASE `#{ENV.fetch('MYSQL_DATABASE')}`;")
 
 connector = MysqlFramework::Connector.new
 connector.query("DROP TABLE IF EXISTS `#{ENV.fetch('MYSQL_DATABASE')}`.`gems`")
-connector.query("CREATE TABLE `#{ENV.fetch('MYSQL_DATABASE')}`.`gems` (
-                  `id` CHAR(36) NOT NULL,
-                  `name` VARCHAR(255) NULL,
-                  `author` VARCHAR(255) NULL,
-                  `created_at` DATETIME,
-                  `updated_at` DATETIME,
-                  PRIMARY KEY (`id`)
-               )")
+connector.query(<<~SQL)
+  CREATE TABLE `#{ENV.fetch('MYSQL_DATABASE')}`.`gems` (
+    `id` CHAR(36) NOT NULL,
+    `name` VARCHAR(255) NULL,
+    `author` VARCHAR(255) NULL,
+    `created_at` DATETIME,
+    `updated_at` DATETIME,
+    PRIMARY KEY (`id`)
+  )
+SQL


### PR DESCRIPTION
This is to avoid checking out a new connection in the middle of a transaction, for example.