### PR TITLE
Adds support for a min and max connection pool size.

### DIFF
--- a/lib/mysql_framework.rb
+++ b/lib/mysql_framework.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'mysql2'
 require 'redlock'
 
@@ -11,5 +13,4 @@ require_relative 'mysql_framework/sql_table'
 require_relative 'mysql_framework/version'
 
 module MysqlFramework
-
 end

--- a/lib/mysql_framework/logger.rb
+++ b/lib/mysql_framework/logger.rb
@@ -4,12 +4,12 @@ require 'logger'
 
 module MysqlFramework
   def self.logger
-    return @@logger
+    @@logger
   end
 
-  def self.set_logger(logger)
+  def self.logger=(logger)
     @@logger = logger
   end
 
-  MysqlFramework.set_logger(Logger.new(STDOUT))
+  MysqlFramework.logger = Logger.new(STDOUT)
 end

--- a/lib/mysql_framework/version.rb
+++ b/lib/mysql_framework/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MysqlFramework
-  VERSION = '0.0.4'
+  VERSION = '0.0.5'
 end

--- a/spec/lib/mysql_framework/connector_spec.rb
+++ b/spec/lib/mysql_framework/connector_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 describe MysqlFramework::Connector do
+  let(:start_pool_size) { Integer(ENV.fetch('MYSQL_START_POOL_SIZE')) }
+  let(:max_pool_size) { Integer(ENV.fetch('MYSQL_MAX_POOL_SIZE')) }
   let(:default_options) do
     {
       host: ENV.fetch('MYSQL_HOST'),
@@ -15,26 +15,28 @@ describe MysqlFramework::Connector do
   end
   let(:options) do
     {
-      host: 'host',
-      port: 'port',
-      database: 'database',
-      username: 'username',
-      password: 'password',
-      reconnect: true
+      host: ENV.fetch('MYSQL_HOST'),
+      port: ENV.fetch('MYSQL_PORT'),
+      database: "#{ENV.fetch('MYSQL_DATABASE')}_2",
+      username: ENV.fetch('MYSQL_USERNAME'),
+      password: ENV.fetch('MYSQL_PASSWORD'),
+      reconnect: false
     }
   end
-  let(:client) { double }
+  let(:client) { double(close: true) }
   let(:gems) { MysqlFramework::SqlTable.new('gems') }
   let(:existing_client) { Mysql2::Client.new(default_options) }
 
   subject { described_class.new }
 
-  describe '#initialize' do
-    it 'sets default query options on the Mysql2 client' do
-      subject
+  before(:each) { subject.setup }
+  after(:each) { subject.dispose }
 
-      expect(Mysql2::Client.default_query_options[:symbolize_keys]).to eq(true)
-      expect(Mysql2::Client.default_query_options[:cast_booleans]).to eq(true)
+  describe '#initialize' do
+    context 'when options are not provided' do
+      it 'returns the default options' do
+        expect(subject.instance_variable_get(:@options)).to eq(default_options)
+      end
     end
 
     context 'when options are provided' do
@@ -44,26 +46,82 @@ describe MysqlFramework::Connector do
         expect(subject.instance_variable_get(:@options)).to eq(options)
       end
     end
+
+    it 'sets default query options on the Mysql2 client' do
+      subject
+
+      expect(Mysql2::Client.default_query_options[:symbolize_keys]).to eq(true)
+      expect(Mysql2::Client.default_query_options[:cast_booleans]).to eq(true)
+    end
+  end
+
+  describe '#setup' do
+    it 'creates a connection pool with the specified number of conections' do
+      subject.setup
+
+      expect(subject.connections.length).to eq(start_pool_size)
+    end
+  end
+
+  describe '#dispose' do
+    before do
+      subject.connections.clear
+      subject.connections.push(client)
+    end
+
+    it 'closes the idle connections and disposes of the queue' do
+      expect(client).to receive(:close)
+
+      subject.dispose
+
+      expect(subject.connections).to be_nil
+    end
   end
 
   describe '#check_out' do
-    it 'returns a Mysql2::Client instance from the pool' do
-      expect(Mysql2::Client).to receive(:new).with(default_options).and_return(client)
-      expect(subject.check_out).to eq(client)
+    context 'when there are available connections' do
+      before do
+        subject.connections.clear
+        subject.connections.push(client)
+      end
+
+      it 'returns a client instance from the pool' do
+        expect(subject.check_out).to eq(client)
+      end
     end
 
-    context 'when the connection pool has a client available' do
-      it 'returns a client instance from the pool' do
-        subject.instance_variable_get(:@connection_pool).push(client)
+    context "when there are no available connections, and the pool's max size has not been reached" do
+      before do
+        subject.connections.clear
+        subject.connections.push(client)
+      end
 
+      it 'instantiates a new connection and returns it' do
+        subject.check_out
+
+        expect(Mysql2::Client).to receive(:new).with(default_options).and_return(client)
         expect(subject.check_out).to eq(client)
+      end
+    end
+
+    context "when there are no available connections, and the pool's max size has been reached" do
+      before do
+        subject.connections.clear
+        subject.instance_variable_set(:@created_connections, 5)
+
+        5.times { subject.check_in(client) }
+        5.times { subject.check_out }
+      end
+
+      it 'throws a RuntimeError' do
+        expect { subject.check_out }.to raise_error(RuntimeError)
       end
     end
   end
 
   describe '#check_in' do
     it 'returns the provided client to the connection pool' do
-      expect(subject.instance_variable_get(:@connection_pool)).to receive(:push).with(client)
+      expect(subject.connections).to receive(:push).with(client)
 
       subject.check_in(client)
     end
@@ -84,20 +142,8 @@ describe MysqlFramework::Connector do
   describe '#execute' do
     let(:insert_query) do
       MysqlFramework::SqlQuery.new.insert(gems)
-        .into(
-          gems[:id],
-          gems[:name],
-          gems[:author],
-          gems[:created_at],
-          gems[:updated_at]
-        )
-        .values(
-          SecureRandom.uuid,
-          'mysql_framework',
-          'sage',
-          Time.now,
-          Time.now
-        )
+        .into(gems[:id], gems[:name], gems[:author], gems[:created_at], gems[:updated_at])
+        .values(SecureRandom.uuid, 'mysql_framework', 'sage', Time.now, Time.now)
     end
 
     it 'executes the query with parameters' do
@@ -139,43 +185,14 @@ describe MysqlFramework::Connector do
   end
 
   describe '#query_multiple_results' do
-    let(:test) { MysqlFramework::SqlTable.new('test') }
-    let(:manager) { MysqlFramework::Scripts::Manager.new }
-    let(:connector) { MysqlFramework::Connector.new }
-    let(:timestamp) { Time.at(628_232_400) } # 1989-11-28 00:00:00 -0500
-    let(:guid) { 'a3ccb138-48ae-437a-be52-f673beb12b51' }
-    let(:insert) do
-      MysqlFramework::SqlQuery.new.insert(test)
-        .into(test[:id], test[:name], test[:action], test[:created_at], test[:updated_at])
-        .values(guid, 'name', 'action', timestamp, timestamp)
-    end
-    let(:obj) do
-      {
-        id: guid,
-        name: 'name',
-        action: 'action',
-        created_at: timestamp,
-        updated_at: timestamp
-      }
-    end
-
-    before :each do
-      manager.initialize_script_history
-      manager.execute
-
-      connector.execute(insert)
-    end
-
-    after(:each) { manager.drop_all_tables }
-
     it 'returns the results from the stored procedure' do
       query = 'call test_procedure'
       result = subject.query_multiple_results(query)
 
       expect(result).to be_a(Array)
       expect(result.length).to eq(2)
-      expect(result[0]).to eq([])
-      expect(result[1]).to eq([obj])
+      expect(result[0].length).to eq(0)
+      expect(result[1].length).to eq(4)
     end
 
     it 'does not check out a new client when one is provided' do
@@ -186,8 +203,8 @@ describe MysqlFramework::Connector do
 
       expect(result).to be_a(Array)
       expect(result.length).to eq(2)
-      expect(result[0]).to eq([])
-      expect(result[1]).to eq([obj])
+      expect(result[0].length).to eq(0)
+      expect(result[1].length).to eq(4)
     end
   end
 
@@ -208,18 +225,11 @@ describe MysqlFramework::Connector do
         expect(client).to receive(:query).with('ROLLBACK')
 
         begin
-          subject.transaction do
-            raise
-          end
-        rescue StandardError
+          subject.transaction { raise }
+        rescue StandardError => e
+          e.message
         end
       end
-    end
-  end
-
-  describe '#default_options' do
-    it 'returns the default options' do
-      expect(subject.default_options).to eq(default_options)
     end
   end
 end

--- a/spec/lib/mysql_framework/logger_spec.rb
+++ b/spec/lib/mysql_framework/logger_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 describe MysqlFramework do
   describe 'logger' do
     it 'returns the logger' do
@@ -9,11 +7,11 @@ describe MysqlFramework do
     end
   end
 
-  describe 'set_logger' do
+  describe 'logger=' do
     let(:logger) { Logger.new(STDOUT) }
 
     it 'sets the logger' do
-      subject.set_logger(logger)
+      subject.logger = logger
       expect(subject.logger).to eq(logger)
     end
   end

--- a/spec/lib/mysql_framework/scripts/base_spec.rb
+++ b/spec/lib/mysql_framework/scripts/base_spec.rb
@@ -1,25 +1,13 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 describe MysqlFramework::Scripts::Base do
+  let(:client) { double }
+
   subject { described_class.new }
-
-  describe '#partitions' do
-    it 'returns the number of paritions' do
-      expect(subject.partitions).to eq(5)
-    end
-  end
-
-  describe '#database_name' do
-    it 'returns the database name' do
-      expect(subject.database_name).to eq('test_database')
-    end
-  end
 
   describe '#identifier' do
     it 'throws a NotImplementedError' do
-      expect{ subject.identifier }.to raise_error(NotImplementedError)
+      expect { subject.identifier }.to raise_error(NotImplementedError)
     end
 
     context 'when @identifier is set' do
@@ -32,29 +20,24 @@ describe MysqlFramework::Scripts::Base do
 
   describe '#apply' do
     it 'throws a NotImplementedError' do
-      expect{ subject.apply }.to raise_error(NotImplementedError)
+      expect { subject.apply(client) }.to raise_error(NotImplementedError)
     end
   end
 
   describe '#rollback' do
     it 'throws a NotImplementedError' do
-      expect{ subject.rollback }.to raise_error(NotImplementedError)
-    end
-  end
-
-  describe '#generate_partition_sql' do
-    it 'generates the partition sql statement' do
-      expected = "PARTITION p0 VALUES IN (0),\n\tPARTITION p1 VALUES IN (1),\n\tPARTITION p2 VALUES IN (2),\n\tPARTITION p3 VALUES IN (3),\n\tPARTITION p4 VALUES IN (4)"
-      expect(subject.generate_partition_sql).to eq(expected)
+      expect { subject.rollback(client) }.to raise_error(NotImplementedError)
     end
   end
 
   describe '.descendants' do
     it 'returns all descendant classes' do
       expect(described_class.descendants.length).to eq(3)
-      expect(described_class.descendants).to include(MysqlFramework::Support::Scripts::CreateTestTable,
-                                                     MysqlFramework::Support::Scripts::CreateDemoTable,
-                                                     MysqlFramework::Support::Scripts::CreateTestProc)
+      expect(described_class.descendants).to include(
+        MysqlFramework::Support::Scripts::CreateTestTable,
+        MysqlFramework::Support::Scripts::CreateDemoTable,
+        MysqlFramework::Support::Scripts::CreateTestProc
+      )
     end
   end
 
@@ -65,7 +48,6 @@ describe MysqlFramework::Scripts::Base do
   end
 
   describe '#update_procedure' do
-    let(:connector) { MysqlFramework::Connector.new }
     let(:proc_file_path) { 'spec/support/procedure.sql' }
     let(:drop_sql) do
       <<~SQL
@@ -73,19 +55,11 @@ describe MysqlFramework::Scripts::Base do
       SQL
     end
 
-    before :each do
-      subject.instance_variable_set(:@mysql_connector, connector)
-    end
-
     it 'drops and then creates the named procedure' do
-      expect(connector).to receive(:query).with(drop_sql).once
-      expect(connector).to receive(:query).with(File.read(proc_file_path)).once
-      subject.update_procedure('test_procedure', proc_file_path)
-    end
+      expect(client).to receive(:query).with(drop_sql).once
+      expect(client).to receive(:query).with(File.read(proc_file_path)).once
 
-    it 'wraps the call in a transaction' do
-      expect(connector).to receive(:transaction)
-      subject.update_procedure('test_procedure', proc_file_path)
+      subject.update_procedure(client, 'test_procedure', proc_file_path)
     end
   end
 end

--- a/spec/lib/mysql_framework/scripts/manager_spec.rb
+++ b/spec/lib/mysql_framework/scripts/manager_spec.rb
@@ -1,18 +1,20 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 describe MysqlFramework::Scripts::Manager do
-  let(:connector) { MysqlFramework::Connector.new }
-
-  before :each do
-    subject.instance_variable_set(:@mysql_connector, connector)
+  let(:connector) do
+    connector = MysqlFramework::Connector.new
+    connector.setup
+    connector
   end
 
+  subject { described_class.new(connector) }
+
   describe '#execute' do
-    before :each do
+    before(:each) do
+      subject.drop_all_tables
       subject.initialize_script_history
     end
+    after(:each) { subject.drop_all_tables }
 
     it 'executes all pending scripts' do
       expect(subject.table_exists?('demo')).to eq(false)
@@ -23,16 +25,14 @@ describe MysqlFramework::Scripts::Manager do
       expect(subject.table_exists?('demo')).to eq(true)
       expect(subject.table_exists?('test')).to eq(true)
     end
-
-    after :each do
-      subject.drop_all_tables
-    end
   end
 
   describe '#apply_by_tag' do
-    before :each do
+    before(:each) do
+      subject.drop_all_tables
       subject.initialize_script_history
     end
+    after(:each) { subject.drop_all_tables }
 
     it 'executes all pending scripts that match the tag' do
       expect(subject.table_exists?('demo')).to eq(false)
@@ -42,10 +42,6 @@ describe MysqlFramework::Scripts::Manager do
 
       expect(subject.table_exists?('demo')).to eq(false)
       expect(subject.table_exists?('test')).to eq(true)
-    end
-
-    after :each do
-      subject.drop_all_tables
     end
   end
 
@@ -60,9 +56,7 @@ describe MysqlFramework::Scripts::Manager do
   end
 
   describe '#retrieve_last_executed_script' do
-    before :each do
-      subject.initialize_script_history
-    end
+    before(:each) { subject.initialize_script_history }
 
     context 'when no scripts have been executed' do
       it 'returns 0' do
@@ -71,17 +65,12 @@ describe MysqlFramework::Scripts::Manager do
     end
 
     context 'when scripts have been executed previously' do
-      before :each do
-        subject.apply_by_tag([MysqlFramework::Support::Tables::TestTable::NAME])
-      end
+      before(:each) { subject.apply_by_tag([MysqlFramework::Support::Tables::TestTable::NAME]) }
+      after(:each) { subject.drop_script_history }
 
       it 'returns the last executed script' do
         expect(subject.retrieve_last_executed_script).to eq(201807031200)
       end
-    end
-
-    after :each do
-      subject.drop_script_history
     end
   end
 
@@ -131,7 +120,7 @@ describe MysqlFramework::Scripts::Manager do
   describe '#drop_script_history' do
     it 'drops the migration script history table' do
       query = <<~SQL
-        DROP TABLE IF EXISTS `#{ENV.fetch('MYSQL_DATABASE')}`.`migration_script_history`
+        DROP TABLE IF EXISTS `#{ENV.fetch('MYSQL_MIGRATION_TABLE', 'migration_script_history')}`
       SQL
       expect(connector).to receive(:query).with(query)
       subject.drop_script_history
@@ -141,21 +130,21 @@ describe MysqlFramework::Scripts::Manager do
   describe '#drop_table' do
     it 'drops the given table' do
       expect(connector).to receive(:query).with(<<~SQL)
-        DROP TABLE IF EXISTS `some_database`.`some_table`
+        DROP TABLE IF EXISTS `some_table`
       SQL
-      subject.drop_table('`some_database`.`some_table`')
+      subject.drop_table('some_table')
     end
   end
 
   describe '#all_tables' do
     it 'returns all registered tables' do
-      expect(subject.all_tables).to eq(['test', 'demo'])
+      expect(subject.all_tables).to eq(%w(test demo))
     end
   end
 
   describe '.all_tables' do
     it 'stores a class level array of tables' do
-      expect(described_class.all_tables).to eq(['test', 'demo'])
+      expect(described_class.all_tables).to eq(%w(test demo))
     end
   end
 end

--- a/spec/lib/mysql_framework/sql_column_spec.rb
+++ b/spec/lib/mysql_framework/sql_column_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 describe MysqlFramework::SqlColumn do
   subject { described_class.new(table: 'gems', column: 'version') }
 

--- a/spec/lib/mysql_framework/sql_condition_spec.rb
+++ b/spec/lib/mysql_framework/sql_condition_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 describe MysqlFramework::SqlCondition do
   subject { described_class.new(column: 'version', comparison: '=', value: '1.0.0') }
 

--- a/spec/lib/mysql_framework/sql_query_spec.rb
+++ b/spec/lib/mysql_framework/sql_query_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 describe MysqlFramework::SqlQuery do
   let(:gems) { MysqlFramework::SqlTable.new('gems') }
   let(:versions) { MysqlFramework::SqlTable.new('versions') }

--- a/spec/lib/mysql_framework/sql_table_spec.rb
+++ b/spec/lib/mysql_framework/sql_table_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 describe MysqlFramework::SqlTable do
   let(:table) { described_class.new('gems') }
 

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module MysqlFramework
+  module Support
+    class Fixtures
+      def self.execute
+        connector = MysqlFramework::Connector.new(
+          host: ENV.fetch('MYSQL_HOST'),
+          port: ENV.fetch('MYSQL_PORT'),
+          database: nil,
+          username: ENV.fetch('MYSQL_USERNAME'),
+          password: ENV.fetch('MYSQL_PASSWORD')
+        )
+        connector.setup
+
+        client = connector.check_out
+
+        client.query("DROP DATABASE IF EXISTS `#{ENV.fetch('MYSQL_DATABASE')}`;")
+        client.query("DROP DATABASE IF EXISTS `#{ENV.fetch('MYSQL_DATABASE')}_2`;")
+        client.query("CREATE DATABASE `#{ENV.fetch('MYSQL_DATABASE')}`;")
+        client.query("CREATE DATABASE `#{ENV.fetch('MYSQL_DATABASE')}_2`;")
+        client.query("USE `#{ENV.fetch('MYSQL_DATABASE')}`;")
+        client.query(<<~SQL)
+          CREATE TABLE `gems` (
+            `id` CHAR(36) NOT NULL,
+            `name` VARCHAR(255) NULL,
+            `author` VARCHAR(255) NULL,
+            `created_at` DATETIME,
+            `updated_at` DATETIME,
+            PRIMARY KEY (`id`)
+          )
+        SQL
+        client.query(<<~SQL)
+          INSERT INTO `gems`
+          (`id`, `name`, `author`, `created_at`, `updated_at`)
+          VALUES
+          ('#{SecureRandom.uuid}', 'mysql_framework', 'Sage', NOW(), NOW()),
+          ('#{SecureRandom.uuid}', 'sinject', 'Sage', NOW(), NOW())
+        SQL
+
+        connector.check_in(client)
+
+        manager = MysqlFramework::Scripts::Manager.new(connector)
+        manager.execute
+
+        connector.dispose
+      end
+    end
+  end
+end

--- a/spec/support/procedure.sql
+++ b/spec/support/procedure.sql
@@ -1,5 +1,5 @@
 CREATE PROCEDURE `test_procedure`()
 BEGIN
   SELECT * FROM demo;
-  SELECT * FROM test;
+  SELECT * FROM gems;
 END

--- a/spec/support/scripts/create_demo_table.rb
+++ b/spec/support/scripts/create_demo_table.rb
@@ -8,25 +8,34 @@ module MysqlFramework
           @identifier = 201806021520 # 15:20 02/06/2018
         end
 
-        def apply
-          mysql_connector.query(<<~SQL)
-            CREATE TABLE IF NOT EXISTS `#{database_name}`.`demo` (
+        def apply(client)
+          client.query(<<~SQL)
+            CREATE TABLE IF NOT EXISTS `#{table_name}` (
               `id` CHAR(36) NOT NULL,
               `name` VARCHAR(255) NULL,
               `created_at` DATETIME NOT NULL,
-
               `updated_at` DATETIME NOT NULL,
-              PRIMARY KEY (`id`)
+              `partition` INT NOT NULL,
+              PRIMARY KEY (`id`, `partition`)
+            )
+            PARTITION BY LIST(`partition`) (
+              #{generate_partition_sql}
             )
           SQL
         end
 
-        def rollback
+        def rollback(_client)
           raise 'Rollback not supported in test.'
         end
 
         def tags
-          [MysqlFramework::Support::Tables::DemoTable::NAME]
+          [table_name]
+        end
+
+        private
+
+        def table_name
+          MysqlFramework::Support::Tables::DemoTable::NAME
         end
       end
     end

--- a/spec/support/scripts/create_test_proc.rb
+++ b/spec/support/scripts/create_test_proc.rb
@@ -10,16 +10,22 @@ module MysqlFramework
 
         PROC_FILE = 'spec/support/procedure.sql'
 
-        def apply
-          update_procedure('test_procedure', PROC_FILE)
+        def apply(client)
+          update_procedure(client, 'test_procedure', PROC_FILE)
         end
 
-        def rollback
+        def rollback(_client)
           raise 'Rollback not supported in test.'
         end
 
         def tags
-          [MysqlFramework::Support::Tables::TestTable::NAME, 'TestProc']
+          [table_name, 'TestProc']
+        end
+
+        private
+
+        def table_name
+          MysqlFramework::Support::Tables::TestTable::NAME
         end
       end
     end

--- a/spec/support/scripts/create_test_table.rb
+++ b/spec/support/scripts/create_test_table.rb
@@ -8,9 +8,9 @@ module MysqlFramework
           @identifier = 201801011030 # 10:30 01/01/2018
         end
 
-        def apply
-          mysql_connector.query(<<~SQL)
-            CREATE TABLE IF NOT EXISTS `#{database_name}`.`test` (
+        def apply(client)
+          client.query(<<~SQL)
+            CREATE TABLE IF NOT EXISTS `#{table_name}` (
               `id` CHAR(36) NOT NULL,
               `name` VARCHAR(255) NULL,
               `action` VARCHAR(255) NULL,
@@ -21,12 +21,18 @@ module MysqlFramework
             SQL
         end
 
-        def rollback
+        def rollback(_client)
           raise 'Rollback not supported in test.'
         end
 
         def tags
-          [MysqlFramework::Support::Tables::TestTable::NAME]
+          [table_name]
+        end
+
+        private
+
+        def table_name
+          MysqlFramework::Support::Tables::TestTable::NAME
         end
       end
     end


### PR DESCRIPTION
This PR also ensures that a single pool of connections is created and
shared to the migration scripts as opposed to them creating their own
pools.

Additionally, the migration history table name and the migration lock
timeout are now configurable via ENV variables as outlined in the
readme.

Signed-off-by: Rob Kilby <rob.kilby@sage.com>