### PR TITLE
Address a rare issue with query multiple results

### DIFF
--- a/lib/mysql_framework/connector.rb
+++ b/lib/mysql_framework/connector.rb
@@ -77,12 +77,14 @@ module MysqlFramework
 
     # This method is called to execute a query which will return multiple result sets in an array
     def query_multiple_results(query_string, provided_client = nil)
-      with_client(provided_client) do |client|
+      results = with_client(provided_client) do |client|
         result = []
-        result << client.query(query_string).to_a
-        result << client.store_result&.to_a while client.next_result
+        result << client.query(query_string)
+        result << client.store_result while client.next_result
         result.compact
       end
+
+      results.map(&:to_a)
     end
 
     # This method is called to use a client within a transaction

--- a/lib/mysql_framework/version.rb
+++ b/lib/mysql_framework/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MysqlFramework
-  VERSION = '0.0.5'
+  VERSION = '0.0.6'
 end


### PR DESCRIPTION
Occasionally, it was observed that a stored procedure with multiple
statements would fail to return results for some of them.

Although virtually impossible to confirm, we hypothesize that this is
due to the `MySQL2::Result` objects being accessed before they have time
to be fully realized due to the asynchronous nature of MySQL.

This PR waits until all results have been fully gathered before mapping
the objects to arrays, allowing time for the stored proc to execute
fully.

Previously, we were observing a failure rate of approx 1%. With this fix
we have run 100,000 iterations of the same test, resulting in 0
failures.