### PR TITLE
Ping the server on checkout to force a reconnect.

### DIFF
--- a/lib/mysql_framework/connector.rb
+++ b/lib/mysql_framework/connector.rb
@@ -38,8 +38,7 @@ module MysqlFramework
     def check_out
       client = @connection_pool.pop(true)
 
-      # Prevent "mysql server has gone away" errors by detecting dead clients and creating a new one instead.
-      client = new_client if client.closed?
+      client.ping if @options[:reconnect]
 
       client
     rescue ThreadError
@@ -56,6 +55,8 @@ module MysqlFramework
 
     # This method is called to check a client back in to the connection when no longer needed.
     def check_in(client)
+      client = new_client if client.closed?
+
       @connection_pool.push(client)
     end
 

--- a/lib/mysql_framework/version.rb
+++ b/lib/mysql_framework/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MysqlFramework
-  VERSION = '0.0.8'
+  VERSION = '0.0.9'
 end


### PR DESCRIPTION
This is done instead of checking for closed connections on check-out (this is done on check-in instead).