### PR TITLE
Ensures that MYSQL_MIGRATION_LOCK_TTL is cast to an int.

### DIFF
--- a/lib/mysql_framework/scripts/manager.rb
+++ b/lib/mysql_framework/scripts/manager.rb
@@ -117,7 +117,7 @@ module MysqlFramework
       end
 
       def migration_ttl
-        @migration_ttl ||= ENV.fetch('MYSQL_MIGRATION_LOCK_TTL', 2000)
+        @migration_ttl ||= Integer(ENV.fetch('MYSQL_MIGRATION_LOCK_TTL', 2000))
       end
 
       def migration_table_name

--- a/lib/mysql_framework/version.rb
+++ b/lib/mysql_framework/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MysqlFramework
-  VERSION = '0.0.11'
+  VERSION = '0.0.12'
 end


### PR DESCRIPTION
When not set, this value defaulted to 2000 which the lock provider dealt with fine. When the value was provided via an environment variable, it would cast the original value to a string and cause issues when used.