### PR TITLE
Added blocking atomic locks around migrations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ gem 'mysql_framework'
 
 * `MYSQL_MIGRATION_TABLE` - the name of the table that holds a record of applied migrations (default: `migration_script_history`)
 * `MYSQL_MIGRATION_LOCK_TTL` - how long the tables should be locked for whilst performing migrations (default: `2000` / `2 seconds`)
+* `MYSQL_MIGRATION_LOCK_MAX_ATTEMPTS` - how many times the lock manager should attempt to acquire the lock before failing (default: `300`)
+* `MYSQL_MIGRATION_LOCK_RETRY_DELAY_S` - how long the lock manager should sleep between lock request attempts (default: `1 second`)
 * `REDIS_URL` - The URL for redis - used for managing locks for DB migrations
 
 #### Miscellaneous Variables

--- a/lib/mysql_framework.rb
+++ b/lib/mysql_framework.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'mysql2'
-require 'redlock'
 
 require_relative 'mysql_framework/connector'
 require_relative 'mysql_framework/logger'

--- a/lib/mysql_framework/scripts.rb
+++ b/lib/mysql_framework/scripts.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 require_relative 'scripts/base'
+require_relative 'scripts/lock_manager'
 require_relative 'scripts/manager'
 require_relative 'scripts/table'

--- a/lib/mysql_framework/scripts/lock_manager.rb
+++ b/lib/mysql_framework/scripts/lock_manager.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'redlock'
+
+module MysqlFramework
+  module Scripts
+    class LockManager
+      def initialize
+        @pool = Queue.new
+      end
+
+      def fetch_client
+        @pool.pop(true)
+      rescue StandardError
+        # By not letting redlock retry we will rely on the retry that happens in this class
+        Redlock::Client.new([redis_url], retry_jitter: retry_jitter, retry_count: 1, retry_delay: 0)
+      end
+
+      def with
+        client = fetch_client
+        yield client
+      ensure
+        @pool.push(client)
+      end
+
+      # This method is called to request a lock (Default 5 minutes)
+      def request_lock(key:, ttl: default_ttl, max_attempts: default_max_retries, retry_delay: default_retry_delay)
+        MysqlFramework.logger.info { "[#{self.class}] - Requesting lock: #{key}." }
+
+        lock = false
+        count = 0
+
+        loop do
+          # request a lock
+          lock = with { |client| client.lock(key, ttl) }
+
+          # if lock was received break out of the loop
+          break if lock != false && !lock.nil?
+
+          # lock was not received so increment request count
+          count += 1
+
+          MysqlFramework.logger.debug do
+            "[#{self.class}] - Key is currently locked, waiting for lock: #{key} | Wait count: #{count}."
+          end
+
+          # check if lock requests have exceeded max request attempts
+          raise "Resource is already locked. Lock key: #{key}. Max attempt exceeded." if count == max_attempts
+
+          # sleep and try requesting the lock again
+          sleep(retry_delay)
+        end
+
+        lock
+      end
+
+      # This method is called to release a lock
+      def release_lock(key:, lock:)
+        return if lock.nil?
+
+        MysqlFramework.logger.info { "[#{self.class}] - Releasing lock: #{key}." }
+
+        with { |client| client.unlock(lock) }
+      end
+
+      def with_lock(key:, ttl: default_ttl, max_attempts: default_max_retries, retry_delay: default_retry_delay)
+        raise 'Block must be specified.' unless block_given?
+
+        begin
+          lock = request_lock(key: key, ttl: ttl, max_attempts: max_attempts, retry_delay: retry_delay)
+          yield
+        ensure
+          release_lock(key: key, lock: lock)
+        end
+      end
+
+      private
+
+      def redis_url
+        ENV['REDIS_URL']
+      end
+
+      def default_ttl
+        @default_ttl ||= Integer(ENV.fetch('MYSQL_MIGRATION_LOCK_TTL', 2000))
+      end
+
+      def default_max_retries
+        @default_max_retries ||= Integer(ENV.fetch('MYSQL_MIGRATION_LOCK_MAX_ATTEMPTS', 300))
+      end
+
+      def default_retry_delay
+        @default_retry_delay ||= Float(ENV.fetch('MYSQL_MIGRATION_LOCK_RETRY_DELAY_S', 1.0))
+      end
+
+      def retry_jitter
+        @retry_jitter ||= Integer(ENV.fetch('MYSQL_MIGRATION_LOCK_JITTER_MS', 50))
+      end
+    end
+  end
+end

--- a/lib/mysql_framework/version.rb
+++ b/lib/mysql_framework/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MysqlFramework
-  VERSION = '0.0.12'
+  VERSION = '0.1.0'
 end

--- a/spec/lib/mysql_framework/scripts/lock_manager_spec.rb
+++ b/spec/lib/mysql_framework/scripts/lock_manager_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+RSpec.describe MysqlFramework::Scripts::LockManager do
+  describe '#fetch_client' do
+    context 'when the connection pool is empty' do
+      it 'returns a new redlock client' do
+        expect(subject.fetch_client).to be_a(Redlock::Client)
+      end
+    end
+
+    context 'when the connection pool is NOT empty' do
+      let(:client) { Redlock::Client.new([ENV['REDIS_URL']]) }
+
+      before do
+        pool = subject.instance_variable_get(:@pool)
+        pool.push(client)
+      end
+
+      it 'returns a redlock client from the pool' do
+        expect(subject.fetch_client).to eq client
+      end
+    end
+  end
+
+  describe '#with_lock' do
+    let(:key) { SecureRandom.uuid }
+
+    context 'When key is NOT locked' do
+      context 'when a block is specified' do
+        let(:foo) { {} }
+
+        it 'requests a lock, executes the block and releases the lock' do
+          subject.with_lock(key: key, ttl: 1_000) do
+            foo[:bar] = 'abc'
+            sleep(0.1)
+          end
+
+          expect(foo[:bar]).to eq 'abc'
+          expect(subject.request_lock(key: key)).not_to be_nil
+        end
+      end
+    end
+  end
+
+  describe '#request_lock' do
+    let(:key) { SecureRandom.uuid }
+
+    context 'When key is NOT locked' do
+      it 'returns a lock' do
+        expect(subject.request_lock(key: key)).not_to be_nil
+      end
+    end
+
+    context 'When key is locked' do
+      before { subject.request_lock(key: key, ttl: 3_000) }
+
+      context 'but the lock expires within the wait ttl' do
+        it 'returns a lock' do
+          expect(subject.request_lock(key: key, max_attempts: 5, retry_delay: 1)).not_to be_nil
+        end
+      end
+
+      it 'raises a KeyLockError' do
+        expect { subject.request_lock(key: key, max_attempts: 1, retry_delay: 1) }.to raise_error(RuntimeError)
+      end
+    end
+  end
+
+  describe '#release_lock' do
+    let(:key) { SecureRandom.uuid }
+    let(:lock) { subject.request_lock(key: key) }
+
+    it 'releases the lock' do
+      expect { subject.release_lock(key: key, lock: lock) }.not_to raise_error
+      expect(subject.request_lock(key: key, max_attempts: 1, retry_delay: 1)).not_to be_nil
+    end
+
+    context 'when lock is nil' do
+      it 'does not error' do
+        expect { subject.release_lock(key: key, lock: nil) }.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is intended to ease the situation where multiple instances of an application are running, and are each separately trying to apply migrations during startup.

Currently, this would result in an Exception being raised when a lock could not be obtained - this implementation blocks (within a defined retry limit) until the lock is either released or becomes available in some other way.