### PR TITLE
Adds an option to disable connection pooling.

### DIFF
--- a/lib/mysql_framework/version.rb
+++ b/lib/mysql_framework/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MysqlFramework
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end


### PR DESCRIPTION
Sometimes, running with a connection pool is undesirable. This PR adds a new ENV variable that allows connection pooling to be turned off - this variable defaults to `true` so upgrading to a release with this code in will be backwards compatible.