### PR TITLE
Add support for IS NULL / IS NOT NULL to SqlCondition

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,5 @@ group :test, :development do
 end
 
 group :test do
-  gem 'simplecov', require: false
+  gem 'simplecov', '0.17.1', require: false
 end

--- a/lib/mysql_framework/sql_condition.rb
+++ b/lib/mysql_framework/sql_condition.rb
@@ -26,6 +26,8 @@ module MysqlFramework
     end
 
     # This method is called to get the condition as a string for a sql prepared statement
+    #
+    # @return [String]
     def to_s
       return "#{@column} #{@comparison.upcase}" if nil_comparison?
 

--- a/lib/mysql_framework/sql_condition.rb
+++ b/lib/mysql_framework/sql_condition.rb
@@ -12,7 +12,11 @@ module MysqlFramework
       @column = column
       @comparison = comparison
 
-      raise ArgumentError, "Cannot set value when comparison is #{comparison}" if nil_comparison? && value != nil
+      if nil_comparison?
+        raise ArgumentError, "Cannot set value when comparison is #{comparison}" if value != nil
+      else
+        raise ArgumentError, "Comparison of #{comparison} requires value to be not nil" if value.nil?
+      end
 
       @value = value
     end

--- a/lib/mysql_framework/sql_condition.rb
+++ b/lib/mysql_framework/sql_condition.rb
@@ -21,7 +21,8 @@ module MysqlFramework
       @column = column
       @comparison = comparison
 
-      @value = value if valid_value?(value)
+      validate(value)
+      @value = value
     end
 
     # This method is called to get the condition as a string for a sql prepared statement
@@ -37,11 +38,9 @@ module MysqlFramework
       NIL_COMPARISONS.include?(@comparison.upcase)
     end
 
-    def valid_value?(value)
+    def validate(value)
       raise ArgumentError, "Cannot set value when comparison is #{@comparison}" if invalid_null_condition?(value)
       raise ArgumentError, "Comparison of #{@comparison} requires value to be not nil" if invalid_nil_value?(value)
-
-      true
     end
 
     def invalid_null_condition?(value)

--- a/lib/mysql_framework/sql_condition.rb
+++ b/lib/mysql_framework/sql_condition.rb
@@ -3,18 +3,31 @@
 module MysqlFramework
 # This class is used to represent a Sql Condition for a column.
   class SqlCondition
+    NIL_COMPARISONS = ['IS NULL', 'IS NOT NULL'].freeze
+
     # This method is called to get the value of this condition for prepared statements.
     attr_reader :value
 
-    def initialize(column:, comparison:, value:)
+    def initialize(column:, comparison:, value: nil)
       @column = column
       @comparison = comparison
+
+      raise ArgumentError, "Cannot set value when comparison is #{comparison}" if nil_comparison? && value != nil
+
       @value = value
     end
 
     # This method is called to get the condition as a string for a sql prepared statement
     def to_s
+      return "#{@column} #{@comparison.upcase}" if nil_comparison?
+
       "#{@column} #{@comparison} ?"
+    end
+
+    private
+
+    def nil_comparison?
+      NIL_COMPARISONS.include?(@comparison.upcase)
     end
   end
 end

--- a/spec/lib/mysql_framework/sql_condition_spec.rb
+++ b/spec/lib/mysql_framework/sql_condition_spec.rb
@@ -8,4 +8,72 @@ describe MysqlFramework::SqlCondition do
       expect(subject.to_s).to eq('version = ?')
     end
   end
+
+  context 'when comparison is IS NULL' do
+    subject { described_class.new(column: 'version', comparison: 'IS NULL') }
+
+    it 'has a nil value by default' do
+      expect(subject.value).to be_nil
+    end
+
+    context 'when a value is passed to the constructor' do
+      subject { described_class.new(column: 'version', comparison: 'IS NULL', value: 'foo') }
+
+      describe '#new' do
+        it 'raises an ArgumentError if value is set' do
+          expect { subject }.to raise_error(ArgumentError, 'Cannot set value when comparison is IS NULL')
+        end
+      end
+    end
+
+    describe '#to_s' do
+      it 'does not include a value placeholder' do
+        expect(subject.to_s).to eq('version IS NULL')
+      end
+    end
+  end
+
+  context 'when comparison is lowercase is null' do
+    subject { described_class.new(column: 'version', comparison: 'is null') }
+
+    describe '#to_s' do
+      it 'ignores case' do
+        expect(subject.to_s).to eq 'version IS NULL'
+      end
+    end
+  end
+
+  context 'when comparison is IS NOT NULL' do
+    subject { described_class.new(column: 'version', comparison: 'IS NOT NULL') }
+
+    it 'has a nil value by default' do
+      expect(subject.value).to be_nil
+    end
+
+    context 'when a value is passed to the constructor' do
+      subject { described_class.new(column: 'version', comparison: 'IS NOT NULL', value: 'foo') }
+
+      describe '#new' do
+        it 'raises an ArgumentError if value is set' do
+          expect { subject }.to raise_error(ArgumentError, 'Cannot set value when comparison is IS NOT NULL')
+        end
+      end
+    end
+
+    describe '#to_s' do
+      it 'does not include a value placeholder' do
+        expect(subject.to_s).to eq('version IS NOT NULL')
+      end
+    end
+  end
+
+  context 'when comparison is lowercase is not null' do
+    subject { described_class.new(column: 'version', comparison: 'is not null') }
+
+    describe '#to_s' do
+      it 'ignores case' do
+        expect(subject.to_s).to eq 'version IS NOT NULL'
+      end
+    end
+  end
 end

--- a/spec/lib/mysql_framework/sql_condition_spec.rb
+++ b/spec/lib/mysql_framework/sql_condition_spec.rb
@@ -9,6 +9,16 @@ describe MysqlFramework::SqlCondition do
     end
   end
 
+  context 'when comparison is neither IS NULL or IS NOT NULL' do
+    context 'when value is nil' do
+      subject { described_class.new(column: 'version', comparison: '=', value: nil) }
+
+      it 'does raises an ArgumentError' do
+        expect { subject }.to raise_error(ArgumentError, "Comparison of = requires value to be not nil")
+      end
+    end
+  end
+
   context 'when comparison is IS NULL' do
     subject { described_class.new(column: 'version', comparison: 'IS NULL') }
 


### PR DESCRIPTION
Update `SqlCondition` to add support for queries with where clauses such as `column IS NULL` or `column IS NOT NULL`.

If `comparison` is set to either `IS NULL` or `IS NOT NULL` then you shouldn't pass a `value` to the constructor. If you do then an `ArgumentError` is raised.f

## Update
As per PR comment below, this now also raises an `ArgumentError` when comparison is neither `IS NULL` or `IS NOT NULL` and `value = nil`.