### PR TITLE
Only add conditions to params where the value is not nil

### DIFF
--- a/lib/mysql_framework/sql_query.rb
+++ b/lib/mysql_framework/sql_query.rb
@@ -120,11 +120,14 @@ module MysqlFramework
     end
 
     # This method is called to specify a where clause for a query.
+    #
+    # Condition values are added to @params unless the value is nil.
     def where(*conditions)
       @sql += ' WHERE' unless @sql.include?('WHERE')
       @sql += " (#{conditions.join(' AND ')}) "
 
       conditions.each do |condition|
+        next if condition.value.nil?
         if condition.value.is_a?(Enumerable)
           @params.concat(condition.value)
         else

--- a/lib/mysql_framework/version.rb
+++ b/lib/mysql_framework/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MysqlFramework
-  VERSION = '2.0.0'
+  VERSION = '2.0.1'
 end

--- a/spec/lib/mysql_framework/sql_query_spec.rb
+++ b/spec/lib/mysql_framework/sql_query_spec.rb
@@ -50,6 +50,19 @@ describe MysqlFramework::SqlQuery do
       expect(subject.params).to eq(['9876'])
     end
 
+    context 'when a select query contains conditions with nil values' do
+      it 'does not store them as parameters' do
+        subject.select('*')
+          .from(gems, 40)
+          .where(
+            MysqlFramework::SqlCondition.new(column: 'id', comparison: '=', value: 9876),
+            MysqlFramework::SqlCondition.new(column: 'foo', comparison: 'IS NOT NULL'),
+          )
+        expect(subject.sql).to eq('SELECT * FROM `gems` PARTITION (p40) WHERE (id = ? AND foo IS NOT NULL)')
+        expect(subject.params.size).to eq 1
+      end
+    end
+
     it 'builds a joined select query as expected' do
       subject.select('*')
         .from(gems, 40)


### PR DESCRIPTION
Fixes an issue whereby if a SqlCondition has a nil value e.g. `SqlCondition.new(column: 'date_cancelled', comparison: 'IS NULL')` the nil value was still being added to `@params` in `SqlQuery`. This would then lead to a `Bind parameter count does not match number of arguments.

In `SqlQuery#where` when looping through conditions, ignore any whose value is nil.