### PR TITLE
Fix 'Commands out of sync' error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 .idea/*
 .idea
 pkg
+tags

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.1'
 
 services:
   test-runner:
-    image: ruby:2.5
+    image: ruby:2.4
     working_dir: /usr/src/app
     container_name: test-runner
     command: sh -c "while true; do echo 'Container is running..'; sleep 5; done"

--- a/lib/mysql_framework/connector.rb
+++ b/lib/mysql_framework/connector.rb
@@ -81,11 +81,13 @@ module MysqlFramework
     # queries at the same time.
     def execute(query, provided_client = nil)
       with_client(provided_client) do |client|
-        statement = client.prepare(query.sql)
-        result = statement.execute(*query.params)
-        result.to_a if result
-      ensure
-        statement.close if statement
+        begin
+          statement = client.prepare(query.sql)
+          result = statement.execute(*query.params)
+          result.to_a if result
+        ensure
+          statement.close if statement
+        end
       end
     end
 

--- a/lib/mysql_framework/connector.rb
+++ b/lib/mysql_framework/connector.rb
@@ -82,7 +82,8 @@ module MysqlFramework
     def execute(query, provided_client = nil)
       with_client(provided_client) do |client|
         statement = client.prepare(query.sql)
-        statement.execute(*query.params)
+        result = statement.execute(*query.params)
+        result.to_a if result
       ensure
         statement.close if statement
       end

--- a/lib/mysql_framework/connector.rb
+++ b/lib/mysql_framework/connector.rb
@@ -75,10 +75,16 @@ module MysqlFramework
     end
 
     # This method is called to execute a prepared statement
+    #
+    # @note Ensure we close each statement, otherwise we can run into
+    # a 'Commands out of sync' error if multiple threads are running different
+    # queries at the same time.
     def execute(query, provided_client = nil)
       with_client(provided_client) do |client|
         statement = client.prepare(query.sql)
         statement.execute(*query.params)
+      ensure
+        statement.close if statement
       end
     end
 

--- a/lib/mysql_framework/version.rb
+++ b/lib/mysql_framework/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MysqlFramework
-  VERSION = '2.0.1'
+  VERSION = '2.0.2'
 end

--- a/lib/mysql_framework/version.rb
+++ b/lib/mysql_framework/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MysqlFramework
-  VERSION = '2.0.2'
+  VERSION = '2.0.1'
 end

--- a/spec/lib/mysql_framework/connector_spec.rb
+++ b/spec/lib/mysql_framework/connector_spec.rb
@@ -276,8 +276,7 @@ describe MysqlFramework::Connector do
     it 'does not raise a commands out of sync error' do
       threads = []
       threads << Thread.new do
-        350.times do |n|
-          p "t1: #{n}"
+        350.times do
           update_query = MysqlFramework::SqlQuery.new.update('gems')
                                                  .set(updated_at: Time.now)
           expect { subject.execute(update_query) }.not_to raise_error
@@ -285,16 +284,14 @@ describe MysqlFramework::Connector do
       end
 
       threads << Thread.new do
-        350.times do |n|
-          p "t2: #{n}"
+        350.times do
           select_query = MysqlFramework::SqlQuery.new.select('*').from('demo')
           expect { subject.execute(select_query) }.not_to raise_error
         end
       end
 
       threads << Thread.new do
-        350.times do |n|
-          p "t3: #{n}"
+        350.times do
           select_query = MysqlFramework::SqlQuery.new.select('*').from('test')
           expect { subject.execute(select_query) }.not_to raise_error
         end


### PR DESCRIPTION
In a multi-threaded situation, it was possible to get a `Commands out of sync` error due to multiple statements being open at once.

This PR fixes this by ensuring that `#close` is called on each statement. 

So that we can still work with any results returned from a query, we call `#to_a` on the result object before returning.