### PR TITLE
Handle nil client parameter in #check_in

### DIFF
--- a/lib/mysql_framework/connector.rb
+++ b/lib/mysql_framework/connector.rb
@@ -59,10 +59,9 @@ module MysqlFramework
 
     # This method is called to check a client back in to the connection when no longer needed.
     def check_in(client)
-      return client.close unless connection_pool_enabled?
+      return client&.close unless connection_pool_enabled?
 
-      client = new_client if client.closed?
-
+      client = new_client if client.nil? || client.closed?
       @connection_pool.push(client)
     end
 

--- a/lib/mysql_framework/version.rb
+++ b/lib/mysql_framework/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MysqlFramework
-  VERSION = '2.1.0'
+  VERSION = '2.1.1'
 end

--- a/spec/lib/mysql_framework/connector_spec.rb
+++ b/spec/lib/mysql_framework/connector_spec.rb
@@ -232,6 +232,24 @@ describe MysqlFramework::Connector do
         subject.check_in(client)
       end
     end
+
+    context 'when client is nil' do
+      let(:client) { nil }
+
+      context 'when connection pooling is enabled' do
+        it 'does not raise an error' do
+          expect { subject.check_in(client) }.not_to raise_error
+        end
+      end
+
+      context 'when connection pooling is disabled' do
+        let(:connection_pooling_enabled) { 'false' }
+
+        it 'does not raise an error' do
+          expect { subject.check_in(client) }.not_to raise_error
+        end
+      end
+    end
   end
 
   describe '#with_client' do


### PR DESCRIPTION
When testing what happens when the connection pool is depleted, it was possible to inadvertently pass `nil` to `#check_in`. This caused an `undefined method close for nil:NilClass` error.

To guard against this:

- Use the safe navigation operator when closing the connection when connection pooling is disabled
- Add a new connection to the connection pool if client is nil when connection pooling is enabled.