### PR TITLE
allow nil condition values for backward compatibility

### DIFF
--- a/lib/mysql_framework/sql_condition.rb
+++ b/lib/mysql_framework/sql_condition.rb
@@ -50,7 +50,12 @@ module MysqlFramework
     end
 
     def invalid_nil_value?(value)
+      return false if skip_nil_validation?
       nil_comparison? == false && value.nil?
+    end
+
+    def skip_nil_validation?
+      ENV.fetch('MYSQL_FRAMEWORK_SKIP_NIL_VALUE_VALIDATION', 'false').downcase == 'true'
     end
   end
 end

--- a/lib/mysql_framework/version.rb
+++ b/lib/mysql_framework/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MysqlFramework
-  VERSION = '2.1.1'
+  VERSION = '2.1.2'
 end

--- a/spec/lib/mysql_framework/sql_condition_spec.rb
+++ b/spec/lib/mysql_framework/sql_condition_spec.rb
@@ -3,6 +3,12 @@
 describe MysqlFramework::SqlCondition do
   subject { described_class.new(column: 'version', comparison: '=', value: '1.0.0') }
 
+  before :each do
+    allow_any_instance_of(MysqlFramework::SqlCondition).to receive(:skip_nil_validation?).and_return(skip_nil_validation)
+  end
+
+  let(:skip_nil_validation) { false }
+
   describe '#to_s' do
     it 'returns the condition as a string for a prepared statement' do
       expect(subject.to_s).to eq('version = ?')
@@ -15,6 +21,14 @@ describe MysqlFramework::SqlCondition do
 
       it 'does raises an ArgumentError' do
         expect { subject }.to raise_error(ArgumentError, "Comparison of = requires value to be not nil")
+      end
+
+      context 'when skip_nil_validation? is true' do
+        let(:skip_nil_validation) { true }
+
+        it 'does not raise an ArgumentError' do
+          expect(subject.value).to be_nil
+        end
       end
     end
   end
@@ -32,6 +46,14 @@ describe MysqlFramework::SqlCondition do
       describe '#new' do
         it 'raises an ArgumentError if value is set' do
           expect { subject }.to raise_error(ArgumentError, 'Cannot set value when comparison is IS NULL')
+        end
+
+        context 'when skip_nil_validation? is true' do
+          let(:skip_nil_validation) { true }
+
+          it 'raises an ArgumentError if value is set' do
+            expect { subject }.to raise_error(ArgumentError, 'Cannot set value when comparison is IS NULL')
+          end
         end
       end
     end
@@ -66,6 +88,14 @@ describe MysqlFramework::SqlCondition do
       describe '#new' do
         it 'raises an ArgumentError if value is set' do
           expect { subject }.to raise_error(ArgumentError, 'Cannot set value when comparison is IS NOT NULL')
+        end
+
+        context 'when skip_nil_validation? is true' do
+          let(:skip_nil_validation) { true }
+
+          it 'raises an ArgumentError if value is set' do
+            expect { subject }.to raise_error(ArgumentError, 'Cannot set value when comparison is IS NOT NULL')
+          end
         end
       end
     end


### PR DESCRIPTION
s1_event_service consumes this gem and recent upgrade to latest version caused ArgumentErrors because we do pass `nil` values to the `eq` condition in places.

This will allow us to continue to do that provided we set the env var to skip that specific validation check.