### PR TITLE
Ensure result.free is called when calling #execute

### DIFF
--- a/lib/mysql_framework/connector.rb
+++ b/lib/mysql_framework/connector.rb
@@ -75,17 +75,18 @@ module MysqlFramework
 
     # This method is called to execute a prepared statement
     #
-    # @note Ensure we close each statement, otherwise we can run into
-    # a 'Commands out of sync' error if multiple threads are running different
-    # queries at the same time.
+    # @note Ensure we free any result and close each statement, otherwise we
+    # can run into a 'Commands out of sync' error if multiple threads are
+    # running different queries at the same time.
     def execute(query, provided_client = nil)
       with_client(provided_client) do |client|
         begin
           statement = client.prepare(query.sql)
           result = statement.execute(*query.params)
-          result.to_a if result
+          result&.to_a
         ensure
-          statement.close if statement
+          result&.free
+          statement&.close
         end
       end
     end

--- a/lib/mysql_framework/version.rb
+++ b/lib/mysql_framework/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MysqlFramework
-  VERSION = '2.1.2'
+  VERSION = '2.1.3'
 end

--- a/spec/lib/mysql_framework/connector_spec.rb
+++ b/spec/lib/mysql_framework/connector_spec.rb
@@ -291,6 +291,35 @@ describe MysqlFramework::Connector do
       expect(results[0][:id]).to eq(guid)
     end
 
+    context 'when cleaning up resources' do
+      let(:mock_client) { double('client') }
+      let(:mock_statement) { double('statement') }
+      let(:mock_result) { double('result') }
+      let(:select_query) { MysqlFramework::SqlQuery.new.select('*').from('demo') }
+
+      before do
+        allow(mock_result).to receive(:to_a)
+        allow(mock_result).to receive(:free)
+
+        allow(mock_statement).to receive(:close)
+        allow(mock_statement).to receive(:execute).and_return(mock_result)
+
+        allow(mock_client).to receive(:prepare).and_return(mock_statement)
+      end
+
+      it 'frees the result' do
+        expect(mock_result).to receive(:free)
+
+        subject.execute(select_query, mock_client)
+      end
+
+      it 'closes the statement' do
+        expect(mock_statement).to receive(:close)
+
+        subject.execute(select_query, mock_client)
+      end
+    end
+
     it 'does not raise a commands out of sync error' do
       threads = []
       threads << Thread.new do


### PR DESCRIPTION
A `Commands out of sync` error can arise if we try and execute a new
query before freeing the result of a previous query. So, where we ensure
we close each statement we also ensure we free the result.