### PR TITLE
Use a mutex when checking out and checking in connections

### DIFF
--- a/lib/mysql_framework/connector.rb
+++ b/lib/mysql_framework/connector.rb
@@ -26,7 +26,7 @@ module MysqlFramework
 
       until @connection_pool.empty?
         conn = @connection_pool.pop(true)
-        conn.close
+        conn&.close
       end
 
       @connection_pool = nil
@@ -67,7 +67,7 @@ module MysqlFramework
       @mutex.synchronize do
         return client&.close unless connection_pool_enabled?
 
-        client = new_client if client.nil? || client.closed?
+        client = new_client if client&.closed?
         @connection_pool.push(client)
       end
     end

--- a/lib/mysql_framework/version.rb
+++ b/lib/mysql_framework/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MysqlFramework
-  VERSION = '2.1.3'
+  VERSION = '2.1.4'
 end

--- a/spec/lib/mysql_framework/connector_spec.rb
+++ b/spec/lib/mysql_framework/connector_spec.rb
@@ -118,6 +118,12 @@ describe MysqlFramework::Connector do
   end
 
   describe '#check_out' do
+    it 'calls synchronize on the mutex' do
+      expect(subject.instance_variable_get(:@mutex)).to receive(:synchronize)
+
+      subject.check_out
+    end
+
     context 'when connection pooling is enabled' do
       context 'when there are available connections' do
         before do
@@ -203,6 +209,12 @@ describe MysqlFramework::Connector do
   end
 
   describe '#check_in' do
+    it 'calls synchronize on the mutex' do
+      expect(subject.instance_variable_get(:@mutex)).to receive(:synchronize)
+
+      subject.check_out
+    end
+
     context 'when connection pooling is enabled' do
       it 'returns the provided client to the connection pool' do
         expect(subject.connections).to receive(:push).with(client)


### PR DESCRIPTION
Update `Connector` to use a mutex, and add `#synchronize` blocks around the `#check_out` and `#check_in` methods.