### PR TITLE
Empty connection pool error handling

### DIFF
--- a/lib/mysql_framework/connector.rb
+++ b/lib/mysql_framework/connector.rb
@@ -77,7 +77,7 @@ module MysqlFramework
       client = provided || check_out
       yield client
     ensure
-      check_in(client) unless provided
+      check_in(client) if client && !provided
     end
 
     # This method is called to execute a prepared statement

--- a/spec/lib/mysql_framework/connector_spec.rb
+++ b/spec/lib/mysql_framework/connector_spec.rb
@@ -425,4 +425,14 @@ describe MysqlFramework::Connector do
       end
     end
   end
+
+  describe 'connection pool error handling' do
+    it 'does not add nil to the pool when full and an attempt is made to use it' do
+      conns = max_pool_size.times.map { subject.check_out }
+      expect { subject.query('select 1') }.to raise_error(RuntimeError)
+      # Previous versions had a bug where a nil would be added to the pool
+      # at this point.
+      expect { subject.connections.pop(true) } .to raise_error(ThreadError)
+    end
+  end
 end

--- a/spec/lib/mysql_framework/connector_spec.rb
+++ b/spec/lib/mysql_framework/connector_spec.rb
@@ -427,6 +427,10 @@ describe MysqlFramework::Connector do
   end
 
   describe 'connection pool error handling' do
+    before do
+      expect(subject).to_not receive(:check_in)
+    end
+
     it 'does not add nil to the pool when full and an attempt is made to use it' do
       conns = max_pool_size.times.map { subject.check_out }
       expect { subject.query('select 1') }.to raise_error(RuntimeError)


### PR DESCRIPTION
Fixes an issue where `nil` is added to the connection pool when `check_out` raises an exception (such as when the pool is exhausted) and an attempt is made to run a query.