### PR TITLE
FOX-2594: Remove LIMIT clause for `index_exists?`

### DIFF
--- a/lib/mysql_framework/scripts/base.rb
+++ b/lib/mysql_framework/scripts/base.rb
@@ -44,10 +44,10 @@ module MysqlFramework
 
       def index_exists?(client, table_name, index_name)
         result = client.query(<<~SQL)
-          SHOW INDEX FROM #{table_name} WHERE Key_name="#{index_name}" LIMIT 1;
+          SHOW INDEX FROM #{table_name} WHERE Key_name="#{index_name}";
         SQL
 
-        result.count == 1
+        result.count >= 1
       end
 
       protected

--- a/lib/mysql_framework/version.rb
+++ b/lib/mysql_framework/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MysqlFramework
-  VERSION = '2.1.4'
+  VERSION = '2.1.5'
 end


### PR DESCRIPTION
Remove `LIMIT 1` clause for `index_exists?` to avoid syntax errors. This will reduce the amount of code needed for migration scripts.