### PR TITLE
PF: Add helper method to check if index is up to date

### DIFF
--- a/lib/mysql_framework/scripts/base.rb
+++ b/lib/mysql_framework/scripts/base.rb
@@ -50,6 +50,20 @@ module MysqlFramework
         result.count >= 1
       end
 
+      def index_up_to_date?(client, table_name, index_name, columns)
+        result = client.query(<<~SQL)
+          SHOW INDEX FROM #{table_name} WHERE Key_name="#{index_name}" ORDER BY Seq_in_index;
+        SQL
+
+        return false if result.size != columns.size
+
+        result.each_with_index do |column, i|
+          return false if column[:Column_name] != columns[i]
+        end
+
+        true
+      end
+
       protected
 
       def generate_partition_sql

--- a/lib/mysql_framework/scripts/base.rb
+++ b/lib/mysql_framework/scripts/base.rb
@@ -52,12 +52,13 @@ module MysqlFramework
 
       def index_up_to_date?(client, table_name, index_name, columns)
         result = client.query(<<~SQL)
-          SHOW INDEX FROM #{table_name} WHERE Key_name="#{index_name}" ORDER BY Seq_in_index;
+          SHOW INDEX FROM #{table_name} WHERE Key_name="#{index_name}";
         SQL
 
         return false if result.size != columns.size
 
-        result.each_with_index do |column, i|
+        index_columns = result.sort_by { |column| column[:Seq_in_index] }
+        index_columns.each_with_index do |column, i|
           return false if column[:Column_name] != columns[i]
         end
 

--- a/lib/mysql_framework/version.rb
+++ b/lib/mysql_framework/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MysqlFramework
-  VERSION = '2.1.5'
+  VERSION = '2.1.6'
 end

--- a/spec/lib/mysql_framework/scripts/base_spec.rb
+++ b/spec/lib/mysql_framework/scripts/base_spec.rb
@@ -86,4 +86,28 @@ describe MysqlFramework::Scripts::Base do
       expect(subject.index_exists?(client,'foo','bar')).to eq(false)
     end
   end
+
+  describe '#index_up_to_date?' do
+    before do
+      expect(client).to receive(:query).and_return(
+        [{ Column_name: 'a' }, { Column_name: 'b' }]
+      )
+    end
+
+    it 'returns true when index is up to date' do
+      expect(subject.index_up_to_date?(client, 'foo', 'bar', ['a', 'b'])).to eq(true)
+    end
+
+    it 'returns false when index is missing a column' do
+      expect(subject.index_up_to_date?(client, 'foo', 'bar', ['a', 'b', 'c'])).to eq(false)
+    end
+
+    it 'returns false when index is having too many columns' do
+      expect(subject.index_up_to_date?(client, 'foo', 'bar', ['a'])).to eq(false)
+    end
+
+    it 'returns false when index has columns in wrong order' do
+      expect(subject.index_up_to_date?(client, 'foo', 'bar', ['b', 'a'])).to eq(false)
+    end
+  end
 end

--- a/spec/lib/mysql_framework/scripts/base_spec.rb
+++ b/spec/lib/mysql_framework/scripts/base_spec.rb
@@ -90,7 +90,7 @@ describe MysqlFramework::Scripts::Base do
   describe '#index_up_to_date?' do
     before do
       expect(client).to receive(:query).and_return(
-        [{ Column_name: 'a' }, { Column_name: 'b' }]
+        [{ Column_name: 'b', Seq_in_index: 2 }, { Column_name: 'a', Seq_in_index: 1 }]
       )
     end
 


### PR DESCRIPTION
Working with `mysql_framework` in other projects needed to ship a custom implementation to check if an index is up to date, to decide if it needs to be re-created. This helper method should be provided by the library instead.