### PR TITLE
Fix script manager lock key

### DIFF
--- a/lib/mysql_framework/scripts/manager.rb
+++ b/lib/mysql_framework/scripts/manager.rb
@@ -8,7 +8,7 @@ module MysqlFramework
       end
 
       def execute
-        lock_manager.with_lock(key: self.class) do
+        lock_manager.with_lock(key: self.class.name) do
           initialize_script_history
 
           executed_scripts = retrieve_executed_scripts

--- a/lib/mysql_framework/version.rb
+++ b/lib/mysql_framework/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MysqlFramework
-  VERSION = '2.1.7'
+  VERSION = '2.1.8'
 end


### PR DESCRIPTION
## Description

mysql_framework depends on `redlock`, without any version restriction.

However, starting with 2.0.0, `redlock` changed its implementation to use the gem `redis-client`, which does not allow passing in a `Class` type as a locking key.

This commit addresses this by using the class name instead. The previous `redis` implementation was calling `#to_s` on the argument, so the end result is the same.

## Relevant links

- https://github.com/redis-rb/redis-client/blob/1ab081c1d0e47df5d55e011c9390c70b2eef6731/lib/redis_client/ruby_connection/resp3.rb#L62
- https://github.com/redis/redis-rb/blob/v3.1.0/lib/redis/connection/command_helper.rb#L18