### PR TITLE
Allow nil conditions in where for backward compatibility

### DIFF
--- a/lib/mysql_framework/sql_query.rb
+++ b/lib/mysql_framework/sql_query.rb
@@ -127,7 +127,7 @@ module MysqlFramework
       @sql += " (#{conditions.join(' AND ')}) "
 
       conditions.each do |condition|
-        next if condition.value.nil?
+        next if condition.value.nil? && !skip_nil_validation?
         if condition.value.is_a?(Enumerable)
           @params.concat(condition.value)
         else
@@ -262,6 +262,12 @@ module MysqlFramework
       @dup_query = " ON DUPLICATE KEY UPDATE #{duplicates.join(', ')}"
 
       self
+    end
+
+    private
+
+    def skip_nil_validation?
+      ENV.fetch('MYSQL_FRAMEWORK_SKIP_NIL_VALUE_VALIDATION', 'false').downcase == 'true'
     end
   end
 end

--- a/spec/lib/mysql_framework/sql_query_spec.rb
+++ b/spec/lib/mysql_framework/sql_query_spec.rb
@@ -233,6 +233,33 @@ describe MysqlFramework::SqlQuery do
         expect(subject.sql).to eq('WHERE (`gems`.`author` = ? AND `gems`.`created_at` > ?) AND (`gems`.`name` IN (?, ?))')
       end
     end
+
+    context 'when condition is nil' do
+      context 'when MYSQL_FRAMEWORK_SKIP_NIL_VALUE_VALIDATION is not present' do
+        it 'concats the parameter collections' do
+          expect { subject.where(gems[:created_at].eq(nil)) }.to raise_error ArgumentError
+        end
+      end
+
+      context 'when MYSQL_FRAMEWORK_SKIP_NIL_VALUE_VALIDATION is present' do
+        after(:each) { ENV.delete('MYSQL_FRAMEWORK_SKIP_NIL_VALUE_VALIDATION') }
+
+        context 'when value is false' do
+          it 'concats the parameter collections' do
+            ENV['MYSQL_FRAMEWORK_SKIP_NIL_VALUE_VALIDATION'] =  'false'
+            expect { subject.where(gems[:created_at].eq(nil)) }.to raise_error ArgumentError
+          end
+        end
+
+        context 'when value is true' do
+          it 'concats the parameter collections' do
+            ENV['MYSQL_FRAMEWORK_SKIP_NIL_VALUE_VALIDATION'] =  'true'
+            query = subject.where(gems[:updated_at].eq(nil))
+            expect(query.params).to eq ['sage', '2018-01-01 00:00:00', nil]
+          end
+        end
+      end
+    end
   end
 
   describe '#and' do


### PR DESCRIPTION
s1_event_service consumes this gem and recent upgrade to latest version caused ArgumentErrors because we do pass `nil` values to the `eq` condition in places.

This will allow us to continue to do that provided we set the env var to skip that specific validation check.

Related:
https://github.com/Sage/mysql_framework/pull/38